### PR TITLE
Actualizar README para especificar HTTPS para solicitudes de host local

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Los scripts `schema.sql` y `data.sql` permiten crear y poblar la base de datos a
     ```bash
     ./mvnw spring-boot:run
     ```
+    > **Nota:** Si estás ejecutando la aplicación localmente y haciendo solicitudes desde tu máquina (ej. usando Postman o un frontend local), asegúrate de usar `https` en la URL (ej. `https://localhost:8080`). Esto es debido a la configuración de seguridad que puede incluir HSTS (HTTP Strict Transport Security), la cual fuerza el uso de HTTPS.
 
 ## Principales Endpoints
 


### PR DESCRIPTION
Se añadió una nota en el archivo README.md para informar a los usuarios que las solicitudes al host local deben usar HTTPS. Esto se debe a que SSL está habilitado en la configuración de la aplicación (`application.yml`), lo que garantiza conexiones seguras incluso para el desarrollo local.